### PR TITLE
Require diff-mode so that diff-mode faces are available

### DIFF
--- a/vdiff.el
+++ b/vdiff.el
@@ -51,6 +51,7 @@
 
 (require 'cl-lib)
 (require 'subr-x)
+(require 'diff-mode)
 
 (defgroup vdiff nil
   "Diff tool that is like vimdiff"


### PR DESCRIPTION
The faces that vdiff inherits from come from diff-mode, so without requiring diff-mode they aren't available.