### PR TITLE
README: evil-collection adds vimdiff-like bindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -139,21 +139,7 @@ prefix in normal state.
 (evil-define-key 'normal vdiff-mode-map "," vdiff-mode-prefix-map)
 #+END_SRC
 
-To match vimdiff bindings some more work is required. The way the =d= command
-for evil is set up makes it difficult to bind =do= and =dp= as they exist in
-vimdiff. Here is a sample set of bindings that avoids this problem (thanks to
-@edkolev for these).
-
-#+BEGIN_SRC emacs-lisp
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "]c" 'vdiff-next-hunk)
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "[c" 'vdiff-previous-hunk)
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "zc" 'vdiff-close-fold)
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "zM" 'vdiff-close-all-folds)
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "zo" 'vdiff-open-fold)
-  (evil-define-minor-mode-key 'normal 'vdiff-mode "zR" 'vdiff-open-all-folds)
-  (evil-define-minor-mode-key 'motion 'vdiff-mode "go" 'vdiff-receive-changes)
-  (evil-define-minor-mode-key 'motion 'vdiff-mode "gp" 'vdiff-send-changes)
-#+END_SRC
+vimdiff-like binding are provided by [[https://github.com/emacs-evil/evil-collection][evil-collection]]'s [[https://github.com/emacs-evil/evil-collection/blob/master/evil-collection-vdiff.el][evil-collection-vdiff.el]]
 
 ** Hydra
 


### PR DESCRIPTION
This PR updates the README section for vimdiff-line key bindings - they are provided by evil-collection, no need for users to bind anything if they already use evil-collection