### PR TITLE
Fix diff opts handling (ignore case / whitespace)

### DIFF
--- a/vdiff.el
+++ b/vdiff.el
@@ -506,6 +506,11 @@ non-nil. Ignore folds if NO-FOLD is non-nil."
   (when vdiff-mode
     (vdiff-refresh)))
 
+(defun vdiff--nonempty-str-to-list (str)
+  "Return a list for a non-empty `STR' or else nil."
+  (unless (string-empty-p str)
+    (ensure-list str)))
+
 ;; * Main overlay refresh routine
 
 (defun vdiff-refresh (&optional post-refresh-function)
@@ -524,9 +529,9 @@ POST-REFRESH-FUNCTION is called when the process finishes."
            (ses vdiff--session)
            (cmd (append
                  base-cmd
-                 (vdiff-session-whitespace-args ses)
+                 (vdiff--nonempty-str-to-list (vdiff-session-whitespace-args ses))
                  (unless (string= (car base-cmd) "git")
-                   (vdiff-session-case-args ses))
+                   (vdiff--nonempty-str-to-list (vdiff-session-case-args ses)))
                  (list "--" tmp-a tmp-b)
                  (when tmp-c
                    (list tmp-c))))

--- a/vdiff.el
+++ b/vdiff.el
@@ -297,7 +297,7 @@ because those are handled differently.")
   (delq nil (apply #'list args)))
 
 (defun vdiff--maybe-list (str)
-  "Return a list with STR as the sole element, or an empty list."
+  "Return a list with STR as the sole element, or an empty list if STR is empty."
   (if (string= str "") '() (list str)))
 
 (defun vdiff--buffer-a-p ()


### PR DESCRIPTION
Inside `vdiff-refresh`, when append is used to build up the diff command, if one of the intermediate args to append is a string and not a list, append will expand it into the string's character values.

So, "-w" becomes 45 119, and this `Wrong type argument: stringp, 45` error message is shown.

Added a small helper that converts non-empty strings using `ensure-list` to avoid this problem. We only want non-empty strings, though, otherwise an empty diff opt would get added as an explicit empty string arg which would cause diff to fail, e.g.

    diff -w "" -- file1 file2

Where we actually want:

    diff -w -- file1 file2

Fixes: #36